### PR TITLE
Generalize hystrostatic input file reading

### DIFF
--- a/pyhams/src/HydroStatic.f90
+++ b/pyhams/src/HydroStatic.f90
@@ -79,23 +79,23 @@ CONTAINS
       READ(4,*) XG(1),XG(2),XG(3)
       READ(4,*)
       DO I=1,6
-       READ(4,120) (MATX(I,J), J=1, 6)
+       READ(4,*) (MATX(I,J), J=1, 6)
       ENDDO
       READ(4,*)
       DO I=1,6
-       READ(4,120) (BLNR(I,J), J=1, 6)
+       READ(4,*) (BLNR(I,J), J=1, 6)
       ENDDO
       READ(4,*)
       DO I=1,6
-       READ(4,120) (BQDR(I,J), J=1, 6)
+       READ(4,*) (BQDR(I,J), J=1, 6)
       ENDDO
       READ(4,*)
       DO I=1,6
-       READ(4,120) (CRS(I,J), J=1, 6)
+       READ(4,*) (CRS(I,J), J=1, 6)
       ENDDO
       READ(4,*)
       DO I=1,6
-       READ(4,120) (KSTF(I,J), J=1, 6)
+       READ(4,*) (KSTF(I,J), J=1, 6)
       ENDDO
       
       DO I=1,6


### PR DESCRIPTION
Previously, the hydrostatic input file had to be formatted specifically using the 120 format, which led to some values being clipped.  This is more general and works fine.